### PR TITLE
Update CI to use Ubuntu 24

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on: [push]
 jobs:
   linters:
     name: Markdown linting
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v2
       with:
-        node-version: '14'
+        node-version: '16'
 
     - name: Install dependencies
       run: npm install markdownlint-cli


### PR DESCRIPTION
Using Ubuntu 20.04 for action runners [is now deprecated](https://github.com/actions/runner-images/issues/11101#top). This PR updates the CI to instead use Ubuntu 24